### PR TITLE
Added cross-spawn to the dependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,6 +7,7 @@
   },
   "main": "lib/index.js",
   "devDependencies": {
+    "cross-spawn": "^2.0.0",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
flowxo-sdk will need it to install its dependencies.

See: flowxo/flowxo-sdk#34